### PR TITLE
Updates write_to shim file to write dataframe in same way redshift lo…

### DIFF
--- a/R/redshift_manipulation.R
+++ b/R/redshift_manipulation.R
@@ -20,7 +20,7 @@ write_shim_data_file = function(df, table_name, action) {
     # write the json out to the target file
     print(paste0("Creating data file: ", file_abs_path, collapse=""))
     write(rjson::toJSON(metadata), file_abs_path)
-    write.table(df, file_abs_path, sep=",", col.names=FALSE, append=TRUE, na='', quote=TRUE, row.names=FALSE)
+    write.table(df, file_abs_path, sep=",", col.names=TRUE, append=TRUE, na='', quote=TRUE, row.names=FALSE)
 
     # move the file to the output directory :( this is a hack we need a better interface around this
     print(paste0("moving data file: ", data_dir_abs_path, collapse=""))

--- a/R/redshift_manipulation.R
+++ b/R/redshift_manipulation.R
@@ -20,7 +20,7 @@ write_shim_data_file = function(df, table_name, action) {
     # write the json out to the target file
     print(paste0("Creating data file: ", file_abs_path, collapse=""))
     write(rjson::toJSON(metadata), file_abs_path)
-    write.table(df, file_abs_path, sep=",", col.names=FALSE, append=TRUE)
+    write.table(df, file_abs_path, sep=",", col.names=FALSE, append=TRUE, na='', quote=TRUE, row.names=FALSE)
 
     # move the file to the output directory :( this is a hack we need a better interface around this
     print(paste0("moving data file: ", data_dir_abs_path, collapse=""))

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ This package exports the following constants:
 * CONST_SOCIAL_CONNECTIONS_STR
 
 
+# Deploy to DWH-*
+
+```
+$ R cmd -e "devtools::install_github('auth0/rauth0')"
+```
+
+
 # Building Docker
 
 CI depends on a docker base image. This image is currently built manually. Whenever core system deps change
@@ -71,4 +78,12 @@ $ docker build -t a0us-docker.jfrog.io/docker/data/r-base -f Dockerfile.base .
 $ docker push a0us-docker.jfrog.io/docker/data/r-base
 ```
 - Push the Image to Artifactory
+
+```
+$ docker push a0us-docker.jfrog.io/docker/data/r-base
+```
+
 - Build the CI Image
+```
+$ docker build -t rauth0 .
+```


### PR DESCRIPTION
This pR tries to achieve paritiy between the shim data file contents and the contents of the data we're writing to s3 for loading into redshift.

We need the same output as this data:

https://github.com/sicarul/redshiftTools/blob/24a2cc60b24337aa2e2dc759d738c2b1a1e7443e/R/internal.R#L26

Which is called by `rs_replace_table`:

https://github.com/sicarul/redshiftTools/blob/24a2cc60b24337aa2e2dc759d738c2b1a1e7443e/R/replace.R#L34


## Tests

```
C02XK5X8JG5L:rauth0 danielmican$ docker run -it rauth0 /bin/bash
root@d2edd996ea70:/# mkdir /tmp/dwhshim/
root@d2edd996ea70:/# mkdir /tmp/dwhshim/data
root@d2edd996ea70:/# mkdir /tmp/dwhshim/staged
# R

> library(rauth0)
> df = data.frame(hello=1, hi=1)
> Sys.setenv(RAUTH0_WRITE_DATA_FILE="1")
> rauth0::write_shim_data_file(df, table_name="test", action="replace")
[1] "Creating data file: /tmp/dwhshim/staged/0ccd302e-81c8-4173-8ce2-e60bcee27516.csv"
[1] "moving data file: /tmp/dwhshim/data/0ccd302e-81c8-4173-8ce2-e60bcee27516.csv"
Warning message:
In write.table(df, file_abs_path, sep = ",", col.names = TRUE, append = TRUE,  :
  appending column names to file
> q()
Save workspace image? [y/n/c]: n
root@5a71bfd51077:/# cat /tmp/dwhshim/data/0ccd302e-81c8-4173-8ce2-e60bcee27516.csv
{"table":"test","action":"replace"}
"hello","hi"
1,1
```

