### PR TITLE
 added sede as login type

### DIFF
--- a/R/variables.R
+++ b/R/variables.R
@@ -3,7 +3,7 @@
 #' Types of events which count as active users for usage consumption, as a vector
 #'
 #' @export
-CONST_LOGIN_TYPES=c('s', 'sepft', 'ssa', 'seoobft', 'seotpft', 'sercft', 'sertft', 'seacft', 'scoa', 'sens')
+CONST_LOGIN_TYPES=c('s', 'sepft', 'ssa', 'seoobft', 'seotpft', 'sercft', 'sertft', 'seacft', 'scoa', 'sens', 'sede')
 
 #' Login types (string)
 #'


### PR DESCRIPTION
This might the change the numbers, but, we are missing this login_type **sede**, we need to add this.

Please refer here as successful login activitiy.

https://coda.io/d/Data_ddcR3JWy6eS/Revops-Finance_sumie#Revops-Finance-Common-Terms_tudnP/r629&modal=true

